### PR TITLE
Add setting to hide scrambled cube

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ const TimerComponent: React.FC<{ timer: Timer.Timer }> = (props) => {
 | Algorithm
 |------------------------------------------------------------------------------
 */
-const Algorithm: React.FC<{ alg: Alg; showSolutions: boolean }> = React.memo(
+const Algorithm: React.FC<{ alg: Alg; showSolutions: boolean; showCube: boolean }> = React.memo(
   (props) => {
     const moves = props.alg.scramble.split(" ");
     return (
@@ -51,7 +51,7 @@ const Algorithm: React.FC<{ alg: Alg; showSolutions: boolean }> = React.memo(
         </div>
         <div className="flex items-center mb-10">
           <img
-            className="block"
+            className={classNames(["block", {"invisible": !props.showCube}])}
             src={`${process.env.PUBLIC_URL}/assets/fl2cases2/${props.alg.id}.png`}
           />
         </div>
@@ -131,6 +131,7 @@ const sum = (a: number, b: number) => a + b;
 const Settings: React.FC<{
   showSolutions: boolean;
   goToNextCaseAfterSolve: boolean;
+  showCube: boolean;
   dispatch: React.Dispatch<Action>;
 }> = React.memo((props) => {
   const toggleShowSolutions = () =>
@@ -141,6 +142,9 @@ const Settings: React.FC<{
 
   const showCasesModal = () =>
     props.dispatch({ type: ActionType.ShowCasesModal });
+
+  const toggleShowCube = () =>
+      props.dispatch({type: ActionType.ToggleShowCube});
   return (
     <div className="border-b-2 border-bottom border-teal-300 p-2 ">
       <label className="flex items-center mb-2">
@@ -151,6 +155,15 @@ const Settings: React.FC<{
           onChange={toggleShowSolutions}
         />
         Show solutions
+      </label>
+      <label className="flex items-center mb-2">
+        <input
+            className="block mr-2"
+            type="checkbox"
+            checked={props.showCube}
+            onChange={toggleShowCube}
+        />
+        Show scrambled Cube
       </label>
       <label className="flex items-center mb-2">
         <input
@@ -184,6 +197,7 @@ interface State {
   goToNextCaseAfterSolve: boolean;
   times: Time[];
   showCasesModal: boolean;
+  showCube: boolean;
 }
 
 const initialState: State = {
@@ -194,6 +208,7 @@ const initialState: State = {
   goToNextCaseAfterSolve: true,
   times: [],
   showCasesModal: false,
+  showCube: true,
 };
 
 /*
@@ -213,6 +228,7 @@ enum ActionType {
   HideCasesModal,
   DeleteTime,
   GoToNextCase,
+  ToggleShowCube,
 }
 
 type Action =
@@ -226,7 +242,8 @@ type Action =
   | { type: ActionType.ShowCasesModal }
   | { type: ActionType.HideCasesModal }
   | { type: ActionType.DeleteTime; recordedAt: number }
-  | { type: ActionType.GoToNextCase };
+  | { type: ActionType.GoToNextCase }
+  | { type: ActionType.ToggleShowCube };
 
 /*
 |------------------------------------------------------------------------------
@@ -290,6 +307,12 @@ const reducer = (state: State, action: Action): State => {
       return {
         ...state,
         goToNextCaseAfterSolve: !state.goToNextCaseAfterSolve,
+      };
+    }
+    case ActionType.ToggleShowCube: {
+      return {
+        ...state,
+        showCube: !state.showCube,
       };
     }
     case ActionType.GoToNextCase: {
@@ -404,6 +427,7 @@ function App() {
           <Settings
             showSolutions={state.showSolutions}
             goToNextCaseAfterSolve={state.goToNextCaseAfterSolve}
+            showCube={state.showCube}
             dispatch={dispatch}
           />
           <Times times={state.times} dispatch={dispatch} />
@@ -413,6 +437,7 @@ function App() {
             <Algorithm
               alg={state.currentAlg}
               showSolutions={state.showSolutions}
+              showCube={state.showCube}
             />
             <TimerComponent timer={state.timer} />
 


### PR DESCRIPTION
This adds a Setting to hide the scrambled cube.

I wanted to have the option to detect the Scrambled by looking at the actual cube, rather then seeing what case I have before scrambling, to closer simulate a real solve. 

The default is the current behavior.
<img width="713" alt="image" src="https://user-images.githubusercontent.com/1771450/198223590-1bbbd981-29ba-4cb0-882c-23fb5be12f8a.png">
<img width="1506" alt="image" src="https://user-images.githubusercontent.com/1771450/198223637-dc2e89c7-3b42-4e8d-ba77-6034cc3b3796.png">


Thanks for the app! Cheers

