### PR TITLE
Fix scramble on case 27

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build:style": "tailwind build src/styles/index.css -o src/styles/tailwind.css",
-    "start": "npm run build:style && react-scripts start",
+    "start": "export NODE_OPTIONS=--openssl-legacy-provider && npm run build:style && react-scripts start",
     "build-static": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/src/algs.ts
+++ b/src/algs.ts
@@ -228,7 +228,7 @@ const algs: Alg[] = [
   },
   {
     id: 27,
-    scramble: `(U R U' R')3`,
+    scramble: `(U R U' R') (U R U' R') (U R U' R')`,
     solutions: [`(U R U' R')3`]
   },
   {


### PR DESCRIPTION
This PR is to fix an issue when rendering the image on case 27. The image is rendered as it was `U R U' R'`, because `sr-visualizer` is ignoring the parentheses.

I also added a `NODE_OPTION` on start, because it doesn't work on Node greater than v16.x